### PR TITLE
Fix TouchEventBus once handling

### DIFF
--- a/app/core/electron/core/eventbus/touch-event.ts
+++ b/app/core/electron/core/eventbus/touch-event.ts
@@ -35,9 +35,19 @@ export class TouchEventBus implements ITouchEventBus<TalexEvents> {
   map: Map<TalexEvents, Set<TouchEventHandlerWrapper>> = new Map();
 
   emit<T extends ITouchEvent<TalexEvents>>(event: TalexEvents, data: T): void {
-    const handlers = this.map.get(event) || new Set<TouchEventHandlerWrapper>();
+    const handlers = this.map.get(event);
+    if (!handlers)
+      return;
 
-    ;[...handlers].forEach((h) => h.handler(data));
+    for (const h of [...handlers]) {
+      h.handler(data);
+
+      if (h.type === EventType.CONSUME)
+        handlers.delete(h);
+    }
+
+    if (!handlers.size)
+      this.map.delete(event);
   }
 
   on(event: TalexEvents, handler: EventHandler): boolean | void {
@@ -213,7 +223,7 @@ export class WindowAllClosedEvent implements ITouchEvent<TalexEvents> {
      * `will-quit` event, and in this case the `window-all-closed` event would not be
      * emitted.
      */
-  name: TalexEvents = TalexEvents.WILL_QUIT;
+  name: TalexEvents = TalexEvents.WINDOW_ALL_CLOSED;
 
   constructor() {
   }


### PR DESCRIPTION
## Summary
- fix once handler cleanup in TouchEventBus
- correct `WindowAllClosedEvent` name constant

## Testing
- `pnpm test:utils` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68468adb5df0832593e0223a3f80e243